### PR TITLE
Tweaked to work on GlassFish 5 nightly build.

### DIFF
--- a/JSF23WebSocket/pom.xml
+++ b/JSF23WebSocket/pom.xml
@@ -16,17 +16,30 @@
     
     <dependencies>
         <dependency>
-            <groupId>jsfgroup</groupId>
-            <artifactId>jsf</artifactId>
+            <groupId>javax.faces</groupId>
+            <artifactId>javax.faces-api</artifactId>
             <version>2.3</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-web-api</artifactId>
-            <version>7.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.0.CR3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.websocket</groupId>
+            <artifactId>javax.websocket-api</artifactId>
+            <version>1.1</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/JSF23WebSocket/src/main/java/config/ConfigurationBean.java
+++ b/JSF23WebSocket/src/main/java/config/ConfigurationBean.java
@@ -1,0 +1,8 @@
+package config;
+
+import javax.faces.annotation.FacesConfig;
+
+@FacesConfig(version = FacesConfig.Version.JSF_2_3)
+public class ConfigurationBean {
+
+}


### PR DESCRIPTION
@AnghelLeonard, thanks for providing JSF 2.3 samples, very useful. I was having problems deploying the WebSocket sample to GlassFish 5, after making some tweaks I was able to get it to deploy successfully.

Feel free to pull my changes so that the version on your repo can be deployed to GlassFish 5.